### PR TITLE
Fix repository link

### DIFF
--- a/argos_chat/pom.xml
+++ b/argos_chat/pom.xml
@@ -156,7 +156,7 @@
     <repositories>
         <repository>
             <id>clojars.org</id>
-            <url>http://clojars.org/repo</url>
+            <url>https://clojars.org/repo</url>
         </repository>
   </repositories>
 </project>


### PR DESCRIPTION
Fix clojars protocol from http to https because newer versions of maven do not allow http anymore.